### PR TITLE
Fixed shifting of the screen due to bug where scrollbar would dissapear

### DIFF
--- a/src/CSS Components/Dashboard.css
+++ b/src/CSS Components/Dashboard.css
@@ -4,15 +4,16 @@
   align-items: center;
   flex-direction: column;
   margin-bottom: 2rem;
-  width: 100%;
+  width: calc(100% - 371px);
   color: var(--text-color);
 }
 .dashboard {
   width: 100%;
   display: flex;
   justify-content: center;
-  /*Fixes strange bug where screen shifts a couple pixels*/
-  max-width: 1914px;
+  /*Fixes strange bug where screen shifts a couple pixels -  doesn't work on other views though*/
+  /* max-width: 1914px; */
+  /* UPDATE THE SHIFTING CAME FROM THE SCROLLBAR DISAPPEARING*/
 }
 .dashboard-content {
   display: flex;
@@ -183,5 +184,10 @@
   }
   .card {
     width: 100%;
+  }
+}
+@media only screen and (min-height: 1000px) and (min-width: 1700px) {
+  .dashboard-content {
+    max-width: 1450px;
   }
 }

--- a/src/CSS Components/TopBar.css
+++ b/src/CSS Components/TopBar.css
@@ -456,3 +456,9 @@
   text-align: center;
   white-space: nowrap;
 }
+@media only screen and (min-height: 1000px) and (min-width: 1700px) {
+  .topbar-content {
+    max-width: 1450px;
+    height: 75px;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@ body {
   height: -webkit-fill-available;
   width: 100%;
   height: 100%;
+  overflow-y: scroll;
 }
 
 html {


### PR DESCRIPTION
The scrollbar would disappear on component where the scrollbar wasn't needed. This added "overflow-y: scroll" on the body element.